### PR TITLE
feat(issue-15): student schedule page with week/month calendar views

### DIFF
--- a/apps/web/__tests__/unit/utils/schedule-helpers.test.ts
+++ b/apps/web/__tests__/unit/utils/schedule-helpers.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getWeekStart,
+  getWeekDays,
+  getMonthGrid,
+  getSessionsForDay,
+  formatTimeRange,
+} from '@/lib/utils/schedule-helpers'
+import type { ScheduleSession } from '@/app/(dashboard)/dashboard/student/schedule/_components/ScheduleCalendar'
+
+// Helper: local-time Date (avoids UTC-midnight timezone traps)
+function localDate(year: number, month: number, day: number): Date {
+  return new Date(year, month, day)
+}
+
+// Helper to make a minimal ScheduleSession for testing
+function makeSession(starts_at: string, ends_at: string): ScheduleSession {
+  return {
+    id: starts_at,
+    title: 'Test Session',
+    starts_at,
+    ends_at,
+    location: null,
+    status: 'scheduled',
+    cohort_name: 'Test Cohort',
+  }
+}
+
+describe('getWeekStart', () => {
+  it('returns Monday when given a Wednesday', () => {
+    // 2026-03-11 is a Wednesday; Monday of that week is 2026-03-09
+    const result = getWeekStart(localDate(2026, 2, 11))
+    expect(result.getDay()).toBe(1) // Monday
+    expect(result.getDate()).toBe(9)
+    expect(result.getMonth()).toBe(2) // March (0-indexed)
+  })
+
+  it('returns the same day when given a Monday', () => {
+    const result = getWeekStart(localDate(2026, 2, 9)) // Monday March 9
+    expect(result.getDay()).toBe(1)
+    expect(result.getDate()).toBe(9)
+  })
+
+  it('returns the previous Monday when given a Sunday', () => {
+    // 2026-03-15 is a Sunday; Monday of that week is 2026-03-09
+    const result = getWeekStart(localDate(2026, 2, 15))
+    expect(result.getDay()).toBe(1)
+    expect(result.getDate()).toBe(9)
+  })
+})
+
+describe('getWeekDays', () => {
+  it('returns exactly 7 days', () => {
+    const weekStart = localDate(2026, 2, 9) // Monday
+    const days = getWeekDays(weekStart)
+    expect(days).toHaveLength(7)
+  })
+
+  it('starts from the Monday provided and ends on Sunday', () => {
+    const weekStart = localDate(2026, 2, 9)
+    const days = getWeekDays(weekStart)
+    expect(days[0].getDay()).toBe(1) // Monday
+    expect(days[6].getDay()).toBe(0) // Sunday
+  })
+
+  it('days are consecutive', () => {
+    const weekStart = localDate(2026, 2, 9)
+    const days = getWeekDays(weekStart)
+    for (let i = 1; i < 7; i++) {
+      expect(days[i].getDate() - days[i - 1].getDate()).toBe(1)
+    }
+  })
+})
+
+describe('getMonthGrid', () => {
+  it('returns exactly 42 dates (6 rows × 7 cols)', () => {
+    const grid = getMonthGrid(2026, 2) // March 2026
+    expect(grid).toHaveLength(42)
+  })
+
+  it('grid for a month whose 1st is Monday starts on that Monday', () => {
+    // 2026-06-01 is a Monday — grid[0] should be June 1 itself
+    const grid = getMonthGrid(2026, 5) // June 2026 (month=5)
+    expect(grid[0].getMonth()).toBe(5) // June
+    expect(grid[0].getDate()).toBe(1)
+    expect(grid[0].getDay()).toBe(1) // Monday
+  })
+
+  it('includes dates from adjacent months for overflow', () => {
+    // March 2026: 1st is a Sunday, grid starts on Mon Feb 23
+    const grid = getMonthGrid(2026, 2)
+    const firstDay = grid[0]
+    expect(firstDay < localDate(2026, 2, 1)).toBe(true)
+  })
+})
+
+describe('getSessionsForDay', () => {
+  it('returns sessions that start on the given day', () => {
+    // Build sessions with explicit local-time ISO strings
+    const day = localDate(2026, 2, 16) // March 16 local
+    const startISO = new Date(2026, 2, 16, 9, 0).toISOString()
+    const endISO = new Date(2026, 2, 16, 10, 0).toISOString()
+    const otherISO = new Date(2026, 2, 17, 9, 0).toISOString()
+    const sessions = [
+      makeSession(startISO, endISO),
+      makeSession(otherISO, new Date(2026, 2, 17, 10, 0).toISOString()),
+    ]
+    const result = getSessionsForDay(sessions, day)
+    expect(result).toHaveLength(1)
+    expect(result[0].starts_at).toBe(startISO)
+  })
+
+  it('returns empty array when no sessions on that day', () => {
+    const startISO = new Date(2026, 2, 16, 9, 0).toISOString()
+    const sessions = [makeSession(startISO, new Date(2026, 2, 16, 10, 0).toISOString())]
+    const day = localDate(2026, 2, 20) // March 20 local
+    const result = getSessionsForDay(sessions, day)
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('formatTimeRange', () => {
+  it('formats a time range and includes separator and AM/PM', () => {
+    const starts = new Date(2026, 2, 16, 9, 0).toISOString()
+    const ends = new Date(2026, 2, 16, 10, 0).toISOString()
+    const result = formatTimeRange(starts, ends)
+    expect(result).toContain('–')
+    expect(result).toMatch(/AM|PM/i)
+  })
+})

--- a/apps/web/src/app/(dashboard)/dashboard/student/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/student/page.tsx
@@ -1,16 +1,13 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { BookOpen, CheckSquare, Star, Award } from 'lucide-react'
+import { createClient } from '@/lib/supabase/server'
 
 const stats = [
   { label: 'Courses Enrolled', value: '3', delta: '+1 this month', icon: BookOpen },
   { label: 'Attendance Rate', value: '92%', delta: '+3% this month', icon: CheckSquare },
   { label: 'Skill Level', value: '2', delta: 'Level 3 in progress', icon: Star },
   { label: 'Credentials', value: '1', delta: 'Earned this term', icon: Award },
-]
-
-const upcomingSessions = [
-  { date: 'Mon Mar 16', course: 'Introduction to Python', location: 'Room 101' },
-  { date: 'Wed Mar 18', course: 'Financial Literacy 101', location: 'Room 204' },
-  { date: 'Fri Mar 20', course: 'Leadership Seminar', location: 'Main Hall' },
 ]
 
 const recentActivity = [
@@ -21,7 +18,50 @@ const recentActivity = [
   { action: 'Course enrolled', detail: 'Leadership Seminar', time: '1w ago' },
 ]
 
-export default function StudentPage() {
+export default async function StudentPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  // enrolled cohort IDs
+  const { data: enrollments } = await supabase
+    .from('enrollments')
+    .select('cohort_id')
+    .eq('person_id', user.id)
+    .eq('status', 'active')
+
+  const cohortIds = (enrollments ?? []).map((e: { cohort_id: string }) => e.cohort_id)
+
+  // next 5 upcoming sessions
+  let upcomingSessions: {
+    id: string
+    title: string
+    starts_at: string
+    location: string | null
+    cohort_name: string
+  }[] = []
+
+  if (cohortIds.length > 0) {
+    const { data } = await supabase
+      .from('sessions')
+      .select('id, title, starts_at, location, cohorts(name)')
+      .in('cohort_id', cohortIds)
+      .gte('starts_at', new Date().toISOString())
+      .in('status', ['scheduled', 'in_progress'])
+      .order('starts_at')
+      .limit(5)
+
+    upcomingSessions = (data ?? []).map((s) => ({
+      id: s.id as string,
+      title: s.title as string,
+      starts_at: s.starts_at as string,
+      location: (s.location ?? null) as string | null,
+      cohort_name: (Array.isArray(s.cohorts) ? s.cohorts[0]?.name : (s.cohorts as { name: string } | null)?.name) ?? '',
+    }))
+  }
+
   return (
     <div className="space-y-8">
       {/* Header */}
@@ -60,19 +100,37 @@ export default function StudentPage() {
           style={{ animationDelay: '375ms' }}
         >
           <h2 className="text-lg font-semibold text-foreground">Upcoming Sessions</h2>
-          <ul className="mt-4 divide-y divide-border">
-            {upcomingSessions.map((session) => (
-              <li key={session.date} className="flex items-start justify-between py-3">
-                <div>
-                  <p className="text-sm font-medium text-foreground">{session.course}</p>
-                  <p className="text-xs text-muted-foreground">{session.location}</p>
-                </div>
-                <span className="ml-4 flex-shrink-0 text-xs text-muted-foreground">
-                  {session.date}
-                </span>
-              </li>
-            ))}
-          </ul>
+          {upcomingSessions.length === 0 ? (
+            <p className="mt-4 text-sm text-muted-foreground">No upcoming sessions.</p>
+          ) : (
+            <ul className="mt-4 divide-y divide-border">
+              {upcomingSessions.map(session => (
+                <li key={session.id} className="flex items-start justify-between py-3">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{session.title}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {session.location ?? session.cohort_name}
+                    </p>
+                  </div>
+                  <span className="ml-4 flex-shrink-0 text-xs text-muted-foreground">
+                    {new Date(session.starts_at).toLocaleDateString('en-US', {
+                      weekday: 'short',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="mt-4 text-right">
+            <Link
+              href="/dashboard/student/schedule"
+              className="text-xs font-medium text-primary hover:underline"
+            >
+              View Full Schedule →
+            </Link>
+          </div>
         </div>
 
         {/* Recent activity */}

--- a/apps/web/src/app/(dashboard)/dashboard/student/schedule/_components/ScheduleCalendar.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/student/schedule/_components/ScheduleCalendar.tsx
@@ -1,0 +1,332 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronLeft, ChevronRight, MapPin } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import {
+  getWeekStart,
+  getWeekDays,
+  getMonthGrid,
+  getSessionsForDay,
+  formatTimeRange,
+} from '@/lib/utils/schedule-helpers'
+
+export interface ScheduleSession {
+  id: string
+  title: string
+  starts_at: string
+  ends_at: string
+  location: string | null
+  status: string
+  cohort_name: string
+}
+
+interface Props {
+  sessions: ScheduleSession[]
+  hasEnrollments: boolean
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  scheduled: 'bg-indigo-500',
+  in_progress: 'bg-green-500',
+  completed: 'bg-gray-400',
+  cancelled: 'bg-red-500',
+}
+
+const DAY_HEADERS_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+const DAY_HEADERS_MONTH = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function isToday(date: Date): boolean {
+  const t = new Date()
+  return (
+    date.getFullYear() === t.getFullYear() &&
+    date.getMonth() === t.getMonth() &&
+    date.getDate() === t.getDate()
+  )
+}
+
+function formatMonthTitle(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+}
+
+function formatWeekTitle(weekStart: Date): string {
+  return `Week of ${weekStart.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
+}
+
+export function ScheduleCalendar({ sessions, hasEnrollments }: Props) {
+  const [view, setView] = useState<'week' | 'month'>('week')
+  const [currentDate, setCurrentDate] = useState(() => new Date())
+
+  function goBack() {
+    setCurrentDate(prev => {
+      const d = new Date(prev)
+      if (view === 'week') d.setDate(d.getDate() - 7)
+      else d.setMonth(d.getMonth() - 1)
+      return d
+    })
+  }
+
+  function goForward() {
+    setCurrentDate(prev => {
+      const d = new Date(prev)
+      if (view === 'week') d.setDate(d.getDate() + 7)
+      else d.setMonth(d.getMonth() + 1)
+      return d
+    })
+  }
+
+  function goToday() {
+    setCurrentDate(new Date())
+  }
+
+  if (!hasEnrollments) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-10 text-center">
+        <p className="text-muted-foreground">You&apos;re not enrolled in any cohorts yet.</p>
+      </div>
+    )
+  }
+
+  const weekStart = getWeekStart(currentDate)
+  const weekDays = getWeekDays(weekStart)
+  const monthGrid = getMonthGrid(currentDate.getFullYear(), currentDate.getMonth())
+
+  const title = view === 'week' ? formatWeekTitle(weekStart) : formatMonthTitle(currentDate)
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={goBack}
+            className="rounded-md border border-border bg-card p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+            aria-label="Previous"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <span className="min-w-[180px] text-center text-sm font-medium text-foreground">{title}</span>
+          <button
+            onClick={goForward}
+            className="rounded-md border border-border bg-card p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+            aria-label="Next"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+          <button
+            onClick={goToday}
+            className="ml-2 rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+          >
+            Today
+          </button>
+        </div>
+
+        {/* View toggle */}
+        <div className="flex rounded-md border border-border overflow-hidden">
+          {(['week', 'month'] as const).map(v => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={cn(
+                'px-4 py-1.5 text-xs font-medium transition-colors capitalize',
+                view === v
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-card text-muted-foreground hover:bg-accent hover:text-foreground'
+              )}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Calendar */}
+      {view === 'week' ? (
+        <WeekView days={weekDays} sessions={sessions} />
+      ) : (
+        <MonthView
+          year={currentDate.getFullYear()}
+          month={currentDate.getMonth()}
+          grid={monthGrid}
+          sessions={sessions}
+        />
+      )}
+    </div>
+  )
+}
+
+// ─── Week View ────────────────────────────────────────────────────────────────
+
+function WeekView({ days, sessions }: { days: Date[]; sessions: ScheduleSession[] }) {
+  const hasAnySessions = days.some(d => getSessionsForDay(sessions, d).length > 0)
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border bg-card">
+      <div className="min-w-[640px]">
+        {/* Day headers */}
+        <div className="grid grid-cols-7 border-b border-border">
+          {days.map((day, i) => (
+            <div
+              key={i}
+              className={cn(
+                'px-2 py-3 text-center text-xs font-medium',
+                isToday(day) ? 'bg-primary/10 text-primary' : 'text-muted-foreground'
+              )}
+            >
+              <div>{DAY_HEADERS_WEEK[i]}</div>
+              <div
+                className={cn(
+                  'mx-auto mt-1 flex h-6 w-6 items-center justify-center rounded-full text-sm font-bold',
+                  isToday(day) ? 'bg-primary text-primary-foreground' : 'text-foreground'
+                )}
+              >
+                {day.getDate()}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Day columns */}
+        <div className="grid grid-cols-7 divide-x divide-border">
+          {days.map((day, i) => {
+            const daySessions = getSessionsForDay(sessions, day)
+            return (
+              <div
+                key={i}
+                className={cn(
+                  'min-h-[120px] p-2 space-y-1.5',
+                  isToday(day) ? 'bg-primary/5' : ''
+                )}
+              >
+                {daySessions.map(s => (
+                  <SessionCard key={s.id} session={s} />
+                ))}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {!hasAnySessions && (
+        <div className="py-6 text-center text-sm text-muted-foreground">
+          No sessions this week.
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Month View ───────────────────────────────────────────────────────────────
+
+function MonthView({
+  year,
+  month,
+  grid,
+  sessions,
+}: {
+  year: number
+  month: number
+  grid: Date[]
+  sessions: ScheduleSession[]
+}) {
+  const hasAnySessions = grid.some(d => getSessionsForDay(sessions, d).length > 0)
+
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      {/* Day-of-week headers (Sun–Sat for month grid) */}
+      <div className="grid grid-cols-7 border-b border-border bg-muted/30">
+        {DAY_HEADERS_MONTH.map(h => (
+          <div key={h} className="py-2 text-center text-xs font-medium text-muted-foreground">
+            {h}
+          </div>
+        ))}
+      </div>
+
+      {/* 6 rows × 7 cols */}
+      <div className="grid grid-cols-7 divide-x divide-y divide-border">
+        {grid.map((day, i) => {
+          const isCurrentMonth = day.getMonth() === month && day.getFullYear() === year
+          const daySessions = getSessionsForDay(sessions, day)
+          const overflow = daySessions.length - 3
+
+          return (
+            <div
+              key={i}
+              className={cn(
+                'min-h-[80px] p-1.5',
+                isToday(day) ? 'bg-primary/5' : '',
+                !isCurrentMonth ? 'opacity-40' : ''
+              )}
+            >
+              <span
+                className={cn(
+                  'inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium',
+                  isToday(day)
+                    ? 'bg-primary text-primary-foreground font-bold'
+                    : 'text-foreground'
+                )}
+              >
+                {day.getDate()}
+              </span>
+
+              <div className="mt-0.5 space-y-0.5">
+                {daySessions.slice(0, 3).map(s => (
+                  <div
+                    key={s.id}
+                    className={cn(
+                      'truncate rounded px-1 py-0.5 text-[10px] font-medium text-white',
+                      STATUS_COLORS[s.status] ?? 'bg-indigo-500'
+                    )}
+                    title={s.title}
+                  >
+                    {s.title}
+                  </div>
+                ))}
+                {overflow > 0 && (
+                  <div className="text-[10px] text-muted-foreground pl-1">+{overflow} more</div>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {!hasAnySessions && (
+        <div className="py-6 text-center text-sm text-muted-foreground">
+          No sessions this month.
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Session Card (week view) ─────────────────────────────────────────────────
+
+function SessionCard({ session }: { session: ScheduleSession }) {
+  const dotColor = STATUS_COLORS[session.status] ?? 'bg-indigo-500'
+
+  return (
+    <div className="rounded-md border border-border bg-background p-2 text-xs space-y-1">
+      <div className="flex items-start gap-1.5">
+        <span className={cn('mt-0.5 h-2 w-2 flex-shrink-0 rounded-full', dotColor)} />
+        <span className="font-medium text-foreground leading-tight">{session.title}</span>
+      </div>
+      <div className="text-muted-foreground pl-3.5">
+        {formatTimeRange(session.starts_at, session.ends_at)}
+      </div>
+      {session.location && (
+        <div className="flex items-center gap-1 pl-3.5 text-muted-foreground">
+          <MapPin className="h-2.5 w-2.5 flex-shrink-0" />
+          <span className="truncate">{session.location}</span>
+        </div>
+      )}
+      {session.cohort_name && (
+        <div className="pl-3.5">
+          <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+            {session.cohort_name}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/student/schedule/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/student/schedule/page.tsx
@@ -1,0 +1,61 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { ScheduleCalendar } from './_components/ScheduleCalendar'
+import type { ScheduleSession } from './_components/ScheduleCalendar'
+
+export default async function StudentSchedulePage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  // enrolled cohort IDs (active only)
+  const { data: enrollments } = await supabase
+    .from('enrollments')
+    .select('cohort_id')
+    .eq('person_id', user.id)
+    .eq('status', 'active')
+
+  const cohortIds = (enrollments ?? []).map((e: { cohort_id: string }) => e.cohort_id)
+
+  // 5-month window: 1 month back → 3 months forward
+  const windowStart = new Date()
+  windowStart.setMonth(windowStart.getMonth() - 1)
+  windowStart.setDate(1)
+
+  const windowEnd = new Date()
+  windowEnd.setMonth(windowEnd.getMonth() + 4)
+  windowEnd.setDate(0) // last day of +3 month
+
+  let sessions: ScheduleSession[] = []
+  if (cohortIds.length > 0) {
+    const { data } = await supabase
+      .from('sessions')
+      .select('id, title, starts_at, ends_at, location, status, cohort_id, cohorts(name)')
+      .in('cohort_id', cohortIds)
+      .gte('starts_at', windowStart.toISOString())
+      .lte('starts_at', windowEnd.toISOString())
+      .order('starts_at')
+
+    sessions = (data ?? []).map((s) => ({
+      id: s.id as string,
+      title: s.title as string,
+      starts_at: s.starts_at as string,
+      ends_at: s.ends_at as string,
+      location: (s.location ?? null) as string | null,
+      status: s.status as string,
+      cohort_name: (Array.isArray(s.cohorts) ? s.cohorts[0]?.name : (s.cohorts as { name: string } | null)?.name) ?? '',
+    }))
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">My Schedule</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Your enrolled sessions</p>
+      </div>
+      <ScheduleCalendar sessions={sessions} hasEnrollments={cohortIds.length > 0} />
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -40,6 +40,7 @@ function getNavItems(role: UserRole): NavItem[] {
   const roleItems: Record<UserRole, NavItem[]> = {
     student: [
       base,
+      { label: 'Schedule', href: '/dashboard/student/schedule', icon: Calendar },
       { label: 'Courses', href: '/dashboard/student/courses', icon: BookOpen },
       { label: 'Attendance', href: '/dashboard/student/attendance', icon: CheckSquare },
       { label: 'Skill Passport', href: '/dashboard/student/skills', icon: Star },

--- a/apps/web/src/lib/utils/schedule-helpers.ts
+++ b/apps/web/src/lib/utils/schedule-helpers.ts
@@ -1,0 +1,59 @@
+import type { ScheduleSession } from '@/app/(dashboard)/dashboard/student/schedule/_components/ScheduleCalendar'
+
+// Returns Monday of the week containing `date`
+export function getWeekStart(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay() // 0=Sun, 1=Mon, ..., 6=Sat
+  const diff = day === 0 ? -6 : 1 - day // adjust so Monday=0
+  d.setDate(d.getDate() + diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+// Returns array of 7 Date objects for the week (Mon–Sun)
+export function getWeekDays(weekStart: Date): Date[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(weekStart)
+    d.setDate(d.getDate() + i)
+    return d
+  })
+}
+
+// Returns the 6×7 grid dates for a month calendar (including overflow days)
+export function getMonthGrid(year: number, month: number): Date[] {
+  // First day of month
+  const firstDay = new Date(year, month, 1)
+  // day: 0=Sun, 1=Mon ... we want Mon as col 0
+  const startDow = firstDay.getDay() // 0=Sun
+  const offset = startDow === 0 ? 6 : startDow - 1
+  const gridStart = new Date(firstDay)
+  gridStart.setDate(1 - offset)
+
+  return Array.from({ length: 42 }, (_, i) => {
+    const d = new Date(gridStart)
+    d.setDate(gridStart.getDate() + i)
+    return d
+  })
+}
+
+// Filters sessions to those starting on a given calendar day (local date match)
+export function getSessionsForDay(sessions: ScheduleSession[], day: Date): ScheduleSession[] {
+  const y = day.getFullYear()
+  const m = day.getMonth()
+  const d = day.getDate()
+  return sessions.filter(s => {
+    const sd = new Date(s.starts_at)
+    return sd.getFullYear() === y && sd.getMonth() === m && sd.getDate() === d
+  })
+}
+
+// Formats time range: '9:00 AM – 10:00 AM'
+export function formatTimeRange(starts_at: string, ends_at: string): string {
+  const fmt = (iso: string) =>
+    new Date(iso).toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    })
+  return `${fmt(starts_at)} – ${fmt(ends_at)}`
+}


### PR DESCRIPTION
Closes #15

## Summary

- **Sidebar** — adds a "Schedule" nav item for the `student` role using the already-imported `Calendar` icon
- **Student dashboard** — replaces the hardcoded upcoming sessions list with a real DB query (active enrollment join → next 5 `scheduled`/`in_progress` sessions) and adds a "View Full Schedule →" link
- **`/dashboard/student/schedule`** — new server-rendered page: auth guard → enrolled cohort IDs → 5-month session window → `ScheduleCalendar` client component
- **`ScheduleCalendar`** — `'use client'` week/month calendar with prev/next/today navigation, today highlight, session cards (status dot, time range, location, cohort badge), month day-cell pills (up to 3 + "+N more"), and two distinct empty states (no enrollments / no sessions in view)
- **`schedule-helpers.ts`** — five pure utility functions (`getWeekStart`, `getWeekDays`, `getMonthGrid`, `getSessionsForDay`, `formatTimeRange`) kept framework-free for testability
- **Unit tests** — 12 new tests for all helper functions; all 104 tests pass, 0 TypeScript errors

## Files changed

| File | Action |
|------|--------|
| `src/components/layout/Sidebar.tsx` | +1 line — student Schedule nav item |
| `src/app/(dashboard)/dashboard/student/page.tsx` | Real DB query, "View Full Schedule →" link |
| `src/app/(dashboard)/dashboard/student/schedule/page.tsx` | New server component |
| `src/app/(dashboard)/dashboard/student/schedule/_components/ScheduleCalendar.tsx` | New client calendar component |
| `src/lib/utils/schedule-helpers.ts` | New pure helper utilities |
| `__tests__/unit/utils/schedule-helpers.test.ts` | 12 new unit tests |

## Test plan

- [ ] `pnpm vitest run` — 104 tests pass (12 new)
- [ ] `pnpm tsc --noEmit` — 0 errors
- [ ] Log in as student → Sidebar shows "Schedule" between Dashboard and Courses
- [ ] `/dashboard/student/schedule` loads → week view, today highlighted
- [ ] Student with active enrollments → sees only sessions from their cohorts
- [ ] Student with no enrollments → "You're not enrolled in any cohorts yet."
- [ ] Enrolled student, no sessions in current week → "No sessions this week."
- [ ] Switch to month view → 6×7 grid renders, session pills visible
- [ ] Prev/Next navigate correctly in both views; Today resets to current date
- [ ] Mobile: week view scrolls horizontally
- [ ] Student dashboard → real sessions appear; empty state shows "No upcoming sessions."

🤖 Generated with [Claude Code](https://claude.com/claude-code)